### PR TITLE
fix(widget): extend polling window to prevent black canvas

### DIFF
--- a/js/inline_widget.js
+++ b/js/inline_widget.js
@@ -554,7 +554,7 @@ export async function render({ model, el }) {
     // exponential backoff rather than relying on fixed timeouts.
     syncAll();
     let _pollCount = 0;
-    const _maxPolls = 15;  // ~0 + 100 + 200 + 400 + ... ≈ 6s total
+    const _maxPolls = 30;  // exponential backoff capped at 1s → ~20s total
     function _pollForData() {
       _pollCount++;
       syncAll();
@@ -562,6 +562,7 @@ export async function render({ model, el }) {
       const hasData = bytes && (bytes.byteLength || bytes.length) > 0;
       if (hasData) {
         log("Data arrived after " + _pollCount + " poll(s)");
+        requestAnimationFrame(draw);
         syncAladin();
         initialRA = viewRA; initialDec = viewDec; initialFov = viewFov;
         return;
@@ -575,7 +576,7 @@ export async function render({ model, el }) {
         initialRA = viewRA; initialDec = viewDec; initialFov = viewFov;
       }
     }
-    setTimeout(_pollForData, 100);
+    setTimeout(_pollForData, 50);
 
     // --- Interaction ---
     // (dragging declared earlier for syncView guard)

--- a/src/astrowidget/static/widget.js
+++ b/src/astrowidget/static/widget.js
@@ -554,7 +554,7 @@ export async function render({ model, el }) {
     // exponential backoff rather than relying on fixed timeouts.
     syncAll();
     let _pollCount = 0;
-    const _maxPolls = 15;  // ~0 + 100 + 200 + 400 + ... ≈ 6s total
+    const _maxPolls = 30;  // exponential backoff capped at 1s → ~20s total
     function _pollForData() {
       _pollCount++;
       syncAll();
@@ -562,6 +562,7 @@ export async function render({ model, el }) {
       const hasData = bytes && (bytes.byteLength || bytes.length) > 0;
       if (hasData) {
         log("Data arrived after " + _pollCount + " poll(s)");
+        requestAnimationFrame(draw);
         syncAladin();
         initialRA = viewRA; initialDec = viewDec; initialFov = viewFov;
         return;
@@ -575,7 +576,7 @@ export async function render({ model, el }) {
         initialRA = viewRA; initialDec = viewDec; initialFov = viewFov;
       }
     }
-    setTimeout(_pollForData, 100);
+    setTimeout(_pollForData, 50);
 
     // --- Interaction ---
     // (dragging declared earlier for syncView guard)


### PR DESCRIPTION
## Summary
- Increase `_maxPolls` from 15 to 30, extending the binary data polling window from ~10s to ~20s
- Reduce initial poll delay from 100ms to 50ms for faster rendering on quick connections
- Add `requestAnimationFrame(draw)` after data detection to ensure the GL frame is composited

## Context
Binary traitlet data from anywidget's comm channel can arrive after the previous ~10s polling window, leaving the canvas black. This is the same class of bug fixed in a34a87b but with larger images or slower kernel connections exceeding the extended window.

## Test plan
- [ ] Open a notebook with a large image dataset and verify the widget renders (not black)
- [ ] Re-run saved notebooks and confirm widgets display on kernel reconnect
- [ ] Verify existing `vitest` projection tests still pass