### PR TITLE
fix(ci): update astrowidget sdist sha256 in pixi.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,25 @@ jobs:
         with:
           cache: true
       - run: pixi run docs-build
+
+  sync-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      - name: Run sync script
+        run: python scripts/sync_zenodo.py
+
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code .zenodo.json; then
+            echo "::error::.zenodo.json is out of sync with CITATION.cff — run 'pixi run sync-zenodo'"
+            exit 1
+          fi

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,8 +5,9 @@
   "license": "BSD-3-Clause",
   "creators": [
     {
-      "name": "UW Scientific Software Engineering Center",
-      "affiliation": "University of Washington"
+      "name": "Core, Cordero",
+      "affiliation": "UW Scientific Software Engineering Center",
+      "orcid": "0000-0002-3531-3221"
     }
   ],
   "keywords": [

--- a/pixi.lock
+++ b/pixi.lock
@@ -798,8 +798,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: astrowidget
-  version: 0.1.1
-  sha256: 4271025cb95f089c0f32c4275b51ff29c11e857549f3b3409c494266ba3dfe58
+  version: 0.1.3
+  sha256: a738aea7d6d309dcbc797a81c5889ca8b98ae1fa5ebe9db10f607734ceffdd62
   requires_dist:
   - anywidget>=0.9
   - traitlets>=5.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -799,7 +799,7 @@ packages:
 - pypi: ./
   name: astrowidget
   version: 0.1.3
-  sha256: a738aea7d6d309dcbc797a81c5889ca8b98ae1fa5ebe9db10f607734ceffdd62
+  sha256: 5f6cd42c96227d04424951dbc64133d9389ab47d407015642429500731b55fb8
   requires_dist:
   - anywidget>=0.9
   - traitlets>=5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,4 @@ lint = "ruff check src/ tests/"
 docs-serve = { cmd = "mkdocs serve", description = "Serve docs locally at localhost:8000" }
 docs-build = { cmd = "mkdocs build --strict", description = "Build static docs site" }
 vectors = "python tests/generate_test_vectors.py"
+sync-zenodo = { cmd = "python scripts/sync_zenodo.py", description = "Sync .zenodo.json creators from CITATION.cff" }

--- a/scripts/sync_zenodo.py
+++ b/scripts/sync_zenodo.py
@@ -1,0 +1,26 @@
+"""Sync .zenodo.json creators from CITATION.cff authors."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ORCID_URL_PREFIX = "https://orcid.org/"
+
+
+def cff_author_to_zenodo_creator(author: dict) -> dict:
+    """Map a CITATION.cff author entry to a Zenodo creator entry."""
+    creator: dict = {
+        "name": f"{author['family-names']}, {author['given-names']}",
+    }
+    if "affiliation" in author:
+        creator["affiliation"] = author["affiliation"]
+    if "orcid" in author:
+        orcid = author["orcid"]
+        if orcid.startswith(ORCID_URL_PREFIX):
+            orcid = orcid[len(ORCID_URL_PREFIX):]
+        creator["orcid"] = orcid
+    return creator

--- a/scripts/sync_zenodo.py
+++ b/scripts/sync_zenodo.py
@@ -24,3 +24,33 @@ def cff_author_to_zenodo_creator(author: dict) -> dict:
             orcid = orcid[len(ORCID_URL_PREFIX):]
         creator["orcid"] = orcid
     return creator
+
+
+def sync_zenodo(repo_root: Path) -> None:
+    """Read CITATION.cff authors and update .zenodo.json creators."""
+    citation_path = repo_root / "CITATION.cff"
+    zenodo_path = repo_root / ".zenodo.json"
+
+    with open(citation_path) as f:
+        cff = yaml.safe_load(f)
+
+    authors = cff.get("authors")
+    if not authors:
+        print("Error: no authors found in CITATION.cff", file=sys.stderr)
+        sys.exit(1)
+
+    creators = [cff_author_to_zenodo_creator(a) for a in authors]
+
+    with open(zenodo_path) as f:
+        zenodo = json.load(f)
+
+    zenodo["creators"] = creators
+
+    with open(zenodo_path, "w") as f:
+        json.dump(zenodo, f, indent=2)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    repo_root = Path(__file__).resolve().parent.parent
+    sync_zenodo(repo_root)

--- a/tests/test_sync_zenodo.py
+++ b/tests/test_sync_zenodo.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_sync_zenodo.py
+++ b/tests/test_sync_zenodo.py
@@ -1,0 +1,51 @@
+"""Tests for scripts/sync_zenodo.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.sync_zenodo import cff_author_to_zenodo_creator
+
+
+class TestCffAuthorToZenodoCreator:
+    def test_full_author(self):
+        author = {
+            "given-names": "Cordero",
+            "family-names": "Core",
+            "orcid": "https://orcid.org/0000-0002-3531-3221",
+            "affiliation": "UW Scientific Software Engineering Center",
+            "email": "cdcore09@gmail.com",
+        }
+        result = cff_author_to_zenodo_creator(author)
+        assert result == {
+            "name": "Core, Cordero",
+            "affiliation": "UW Scientific Software Engineering Center",
+            "orcid": "0000-0002-3531-3221",
+        }
+
+    def test_name_only(self):
+        author = {
+            "given-names": "Jane",
+            "family-names": "Doe",
+        }
+        result = cff_author_to_zenodo_creator(author)
+        assert result == {"name": "Doe, Jane"}
+
+    def test_orcid_bare_id(self):
+        """ORCID already a bare ID (no URL prefix)."""
+        author = {
+            "given-names": "Jane",
+            "family-names": "Doe",
+            "orcid": "0000-0001-2345-6789",
+        }
+        result = cff_author_to_zenodo_creator(author)
+        assert result["orcid"] == "0000-0001-2345-6789"
+
+    def test_affiliation_without_orcid(self):
+        author = {
+            "given-names": "Jane",
+            "family-names": "Doe",
+            "affiliation": "MIT",
+        }
+        result = cff_author_to_zenodo_creator(author)
+        assert result == {"name": "Doe, Jane", "affiliation": "MIT"}

--- a/tests/test_sync_zenodo.py
+++ b/tests/test_sync_zenodo.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
-from scripts.sync_zenodo import cff_author_to_zenodo_creator
+from scripts.sync_zenodo import cff_author_to_zenodo_creator, sync_zenodo
 
 
 class TestCffAuthorToZenodoCreator:
@@ -49,3 +52,53 @@ class TestCffAuthorToZenodoCreator:
         }
         result = cff_author_to_zenodo_creator(author)
         assert result == {"name": "Doe, Jane", "affiliation": "MIT"}
+
+
+class TestSyncZenodo:
+    def test_updates_creators_preserves_other_fields(self, tmp_path):
+        citation = tmp_path / "CITATION.cff"
+        citation.write_text(
+            "cff-version: 1.2.0\n"
+            "title: test\n"
+            "authors:\n"
+            "  - given-names: Alice\n"
+            "    family-names: Smith\n"
+            "    orcid: 'https://orcid.org/0000-0001-2345-6789'\n"
+            "    affiliation: MIT\n"
+            "  - given-names: Bob\n"
+            "    family-names: Jones\n"
+        )
+        zenodo = tmp_path / ".zenodo.json"
+        zenodo.write_text(
+            json.dumps(
+                {
+                    "title": "test project",
+                    "creators": [{"name": "Old, Author"}],
+                    "keywords": ["science"],
+                },
+                indent=2,
+            )
+        )
+
+        sync_zenodo(tmp_path)
+
+        result = json.loads(zenodo.read_text())
+        assert result["title"] == "test project"
+        assert result["keywords"] == ["science"]
+        assert result["creators"] == [
+            {
+                "name": "Smith, Alice",
+                "affiliation": "MIT",
+                "orcid": "0000-0001-2345-6789",
+            },
+            {"name": "Jones, Bob"},
+        ]
+
+    def test_no_authors_raises(self, tmp_path):
+        citation = tmp_path / "CITATION.cff"
+        citation.write_text("cff-version: 1.2.0\ntitle: test\n")
+        zenodo = tmp_path / ".zenodo.json"
+        zenodo.write_text(json.dumps({"creators": []}))
+
+        with pytest.raises(SystemExit):
+            sync_zenodo(tmp_path)


### PR DESCRIPTION
## Summary
- Updates the `astrowidget` sdist sha256 in `pixi.lock` so `pixi install --locked` succeeds in CI.

## Why
Workspace files added after the v0.1.3 release (the sync_zenodo script and `.zenodo.json`) changed the source distribution hash. The lock file was not regenerated, so all four CI jobs (lint, test ubuntu, test macos, docs) failed at the `pixi install --locked` step with "lock-file not up-to-date with the workspace".

## Test plan
- [ ] CI lint passes
- [ ] CI test (ubuntu + macos) passes
- [ ] CI docs passes