### PR TITLE
feat(citation): sync pyproject.toml authors from CITATION.cff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install pyyaml
-        run: pip install pyyaml
+      - name: Install dependencies
+        run: pip install pyyaml tomlkit
 
       - name: Run sync script
         run: python scripts/sync_zenodo.py
 
       - name: Check for drift
         run: |
-          if ! git diff --exit-code .zenodo.json; then
-            echo "::error::.zenodo.json is out of sync with CITATION.cff — run 'pixi run sync-zenodo'"
+          if ! git diff --exit-code .zenodo.json pyproject.toml; then
+            echo "::error::Citation metadata is out of sync with CITATION.cff — run 'pixi run sync-zenodo'"
             exit 1
           fi

--- a/pixi.lock
+++ b/pixi.lock
@@ -209,6 +209,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
@@ -454,6 +455,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.5-py314h6c2aa35_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
@@ -799,7 +801,7 @@ packages:
 - pypi: ./
   name: astrowidget
   version: 0.1.3
-  sha256: 5f6cd42c96227d04424951dbc64133d9389ab47d407015642429500731b55fb8
+  sha256: a84b6c329e4527e65c41e38c78fb2efb90e663fa151826b24516d2fa4b76ff3d
   requires_dist:
   - anywidget>=0.9
   - traitlets>=5.0
@@ -4781,6 +4783,17 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 21561
   timestamp: 1774492402955
+- conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
+  sha256: 1cd52f9ccb4854c4d731438afe0e833b6b71edaf5ede661152aa98efb3a7cc70
+  md5: 42ef10a8f7f5d55a2e267c0d5daa6387
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomlkit?source=hash-mapping
+  size: 41169
+  timestamp: 1778423744478
 - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
   name: toolz
   version: 1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.11"
 authors = [
-    { name = "UW Scientific Software Engineering Center" },
+    {name = "Cordero Core", email = "cdcore09@gmail.com"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -87,6 +87,7 @@ bokeh = ">=3.3"
 mkdocs = ">=1.6"
 mkdocs-material = ">=9.5"
 pymdown-extensions = ">=10.0"
+tomlkit = ">=0.13"
 
 [tool.pixi.tasks]
 build = "npm run build"
@@ -98,4 +99,4 @@ lint = "ruff check src/ tests/"
 docs-serve = { cmd = "mkdocs serve", description = "Serve docs locally at localhost:8000" }
 docs-build = { cmd = "mkdocs build --strict", description = "Build static docs site" }
 vectors = "python tests/generate_test_vectors.py"
-sync-zenodo = { cmd = "python scripts/sync_zenodo.py", description = "Sync .zenodo.json creators from CITATION.cff" }
+sync-zenodo = { cmd = "python scripts/sync_zenodo.py", description = "Sync .zenodo.json and pyproject.toml authors from CITATION.cff" }

--- a/scripts/sync_zenodo.py
+++ b/scripts/sync_zenodo.py
@@ -1,4 +1,11 @@
-"""Sync .zenodo.json creators from CITATION.cff authors."""
+"""Sync .zenodo.json and pyproject.toml from CITATION.cff.
+
+CITATION.cff is the single source of truth for author/contributor metadata.
+This script propagates the author list to:
+
+- ``.zenodo.json`` ``creators`` (used by the Zenodo GitHub integration)
+- ``pyproject.toml`` ``[project] authors`` (used by the built Python package)
+"""
 
 from __future__ import annotations
 
@@ -6,6 +13,7 @@ import json
 import sys
 from pathlib import Path
 
+import tomlkit
 import yaml
 
 ORCID_URL_PREFIX = "https://orcid.org/"
@@ -26,10 +34,53 @@ def cff_author_to_zenodo_creator(author: dict) -> dict:
     return creator
 
 
-def sync_zenodo(repo_root: Path) -> None:
-    """Read CITATION.cff authors and update .zenodo.json creators."""
-    citation_path = repo_root / "CITATION.cff"
+def cff_author_to_pyproject_author(author: dict) -> tomlkit.items.InlineTable:
+    """Map a CITATION.cff author entry to a pyproject.toml author entry.
+
+    PEP 621 ``[project] authors`` only supports ``name`` and ``email``.
+    """
+    entry = tomlkit.inline_table()
+    entry["name"] = f"{author['given-names']} {author['family-names']}"
+    if "email" in author:
+        entry["email"] = author["email"]
+    return entry
+
+
+def sync_zenodo(repo_root: Path, cff_authors: list[dict]) -> None:
+    """Write CITATION.cff authors into .zenodo.json creators."""
     zenodo_path = repo_root / ".zenodo.json"
+
+    with open(zenodo_path) as f:
+        zenodo = json.load(f)
+
+    zenodo["creators"] = [cff_author_to_zenodo_creator(a) for a in cff_authors]
+
+    with open(zenodo_path, "w") as f:
+        json.dump(zenodo, f, indent=2)
+        f.write("\n")
+
+
+def sync_pyproject(repo_root: Path, cff_authors: list[dict]) -> None:
+    """Write CITATION.cff authors into pyproject.toml [project] authors."""
+    pyproject_path = repo_root / "pyproject.toml"
+
+    with open(pyproject_path) as f:
+        pyproject = tomlkit.parse(f.read())
+
+    authors_array = tomlkit.array()
+    authors_array.multiline(True)
+    for author in cff_authors:
+        authors_array.append(cff_author_to_pyproject_author(author))
+
+    pyproject["project"]["authors"] = authors_array
+
+    with open(pyproject_path, "w") as f:
+        f.write(tomlkit.dumps(pyproject))
+
+
+def sync(repo_root: Path) -> None:
+    """Read CITATION.cff and propagate authors to dependent files."""
+    citation_path = repo_root / "CITATION.cff"
 
     with open(citation_path) as f:
         cff = yaml.safe_load(f)
@@ -39,18 +90,10 @@ def sync_zenodo(repo_root: Path) -> None:
         print("Error: no authors found in CITATION.cff", file=sys.stderr)
         sys.exit(1)
 
-    creators = [cff_author_to_zenodo_creator(a) for a in authors]
-
-    with open(zenodo_path) as f:
-        zenodo = json.load(f)
-
-    zenodo["creators"] = creators
-
-    with open(zenodo_path, "w") as f:
-        json.dump(zenodo, f, indent=2)
-        f.write("\n")
+    sync_zenodo(repo_root, authors)
+    sync_pyproject(repo_root, authors)
 
 
 if __name__ == "__main__":
     repo_root = Path(__file__).resolve().parent.parent
-    sync_zenodo(repo_root)
+    sync(repo_root)

--- a/tests/test_sync_zenodo.py
+++ b/tests/test_sync_zenodo.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import json
 
 import pytest
+import tomllib
 
-from scripts.sync_zenodo import cff_author_to_zenodo_creator, sync_zenodo
+from scripts.sync_zenodo import (
+    cff_author_to_pyproject_author,
+    cff_author_to_zenodo_creator,
+    sync,
+)
 
 
 class TestCffAuthorToZenodoCreator:
@@ -53,33 +58,76 @@ class TestCffAuthorToZenodoCreator:
         assert result == {"name": "Doe, Jane", "affiliation": "MIT"}
 
 
-class TestSyncZenodo:
-    def test_updates_creators_preserves_other_fields(self, tmp_path):
-        citation = tmp_path / "CITATION.cff"
-        citation.write_text(
-            "cff-version: 1.2.0\n"
-            "title: test\n"
-            "authors:\n"
-            "  - given-names: Alice\n"
-            "    family-names: Smith\n"
-            "    orcid: 'https://orcid.org/0000-0001-2345-6789'\n"
-            "    affiliation: MIT\n"
-            "  - given-names: Bob\n"
-            "    family-names: Jones\n"
+class TestCffAuthorToPyprojectAuthor:
+    def test_with_email(self):
+        author = {
+            "given-names": "Cordero",
+            "family-names": "Core",
+            "email": "cdcore09@gmail.com",
+            "orcid": "https://orcid.org/0000-0002-3531-3221",
+            "affiliation": "UW SSEC",
+        }
+        result = cff_author_to_pyproject_author(author)
+        assert dict(result) == {
+            "name": "Cordero Core",
+            "email": "cdcore09@gmail.com",
+        }
+
+    def test_without_email(self):
+        author = {"given-names": "Jane", "family-names": "Doe"}
+        result = cff_author_to_pyproject_author(author)
+        assert dict(result) == {"name": "Jane Doe"}
+
+
+def _write_fixture_files(tmp_path, *, authors_yaml: str):
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text(
+        "cff-version: 1.2.0\n"
+        "title: test\n"
+        + authors_yaml
+    )
+    zenodo = tmp_path / ".zenodo.json"
+    zenodo.write_text(
+        json.dumps(
+            {
+                "title": "test project",
+                "creators": [{"name": "Old, Author"}],
+                "keywords": ["science"],
+            },
+            indent=2,
         )
-        zenodo = tmp_path / ".zenodo.json"
-        zenodo.write_text(
-            json.dumps(
-                {
-                    "title": "test project",
-                    "creators": [{"name": "Old, Author"}],
-                    "keywords": ["science"],
-                },
-                indent=2,
-            )
+    )
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\n'
+        'name = "demo"\n'
+        'version = "0.0.1"\n'
+        'authors = [\n'
+        '    { name = "Placeholder" },\n'
+        ']\n'
+        '\n'
+        '[tool.something]\n'
+        'preserved = true\n'
+    )
+    return citation, zenodo, pyproject
+
+
+class TestSync:
+    def test_updates_zenodo_creators_preserves_other_fields(self, tmp_path):
+        _, zenodo, _ = _write_fixture_files(
+            tmp_path,
+            authors_yaml=(
+                "authors:\n"
+                "  - given-names: Alice\n"
+                "    family-names: Smith\n"
+                "    orcid: 'https://orcid.org/0000-0001-2345-6789'\n"
+                "    affiliation: MIT\n"
+                "  - given-names: Bob\n"
+                "    family-names: Jones\n"
+            ),
         )
 
-        sync_zenodo(tmp_path)
+        sync(tmp_path)
 
         result = json.loads(zenodo.read_text())
         assert result["title"] == "test project"
@@ -93,11 +141,32 @@ class TestSyncZenodo:
             {"name": "Jones, Bob"},
         ]
 
+    def test_updates_pyproject_authors_preserves_other_sections(self, tmp_path):
+        _, _, pyproject = _write_fixture_files(
+            tmp_path,
+            authors_yaml=(
+                "authors:\n"
+                "  - given-names: Alice\n"
+                "    family-names: Smith\n"
+                "    email: alice@example.com\n"
+                "  - given-names: Bob\n"
+                "    family-names: Jones\n"
+            ),
+        )
+
+        sync(tmp_path)
+
+        data = tomllib.loads(pyproject.read_text())
+        assert data["project"]["name"] == "demo"
+        assert data["project"]["version"] == "0.0.1"
+        assert data["project"]["authors"] == [
+            {"name": "Alice Smith", "email": "alice@example.com"},
+            {"name": "Bob Jones"},
+        ]
+        assert data["tool"]["something"]["preserved"] is True
+
     def test_no_authors_raises(self, tmp_path):
-        citation = tmp_path / "CITATION.cff"
-        citation.write_text("cff-version: 1.2.0\ntitle: test\n")
-        zenodo = tmp_path / ".zenodo.json"
-        zenodo.write_text(json.dumps({"creators": []}))
+        _write_fixture_files(tmp_path, authors_yaml="")
 
         with pytest.raises(SystemExit):
-            sync_zenodo(tmp_path)
+            sync(tmp_path)


### PR DESCRIPTION
## Summary
- Extend the existing CITATION.cff sync to also rewrite `pyproject.toml` `[project] authors`, making CITATION.cff the single source of truth for the published Python package's author metadata (in addition to `.zenodo.json`).
- CI's `sync-check` job now gates drift on both `.zenodo.json` and `pyproject.toml`, so a stale package author list will fail the build the same way a stale Zenodo creators list does.

## Changes
- `scripts/sync_zenodo.py`: refactored to read CITATION.cff once and write to both `.zenodo.json` (Family, Given + ORCID + affiliation) and `pyproject.toml` (PEP 621 `name` + `email`); uses `tomlkit` so the rest of `pyproject.toml` is preserved.
- `pyproject.toml`: added `tomlkit >= 0.13` to `[tool.pixi.feature.dev.dependencies]`; updated `sync-zenodo` task description; `[project] authors` now reflects CITATION.cff.
- `.github/workflows/ci.yml`: install `tomlkit` in the sync-check job and include `pyproject.toml` in the drift check.
- `.zenodo.json`: regenerated (no semantic change for the current single-author case).
- `pixi.lock`: relocked to include `tomlkit`.

## Notes
- PEP 621 `authors` only carries `name` + `email`; ORCID and affiliation remain in `.zenodo.json`.
- The institutional name ("UW Scientific Software Engineering Center") is no longer listed as a package author. To put it back, add it as a `name`-only entity entry in CITATION.cff and re-run the sync.

## Test plan
- [ ] `pixi run sync-zenodo` produces no diff against the committed state (idempotent).
- [ ] Manually edit CITATION.cff (e.g., add a second author), run `pixi run sync-zenodo`, and confirm both `.zenodo.json` and `pyproject.toml` update correctly.
- [ ] CI `sync-check` passes on this branch.
- [ ] CI `sync-check` would fail if `pyproject.toml` is hand-edited out of sync with CITATION.cff (verify by reasoning about the workflow or by a quick local `git diff --exit-code` check).
- [ ] Built wheel/sdist metadata (`python -m build` or equivalent) shows the CITATION.cff author in `Author`/`Author-email`.